### PR TITLE
枠の作成と \cut について 

### DIFF
--- a/exsmple.tex
+++ b/exsmple.tex
@@ -4,8 +4,8 @@
 \usepackage[utf8]{inputenc}
 \usepackage{longtable}
 \usepackage{graphics}
+\usepackage{makecell}
 \usepackage{script}
-
 
 %名前の長さ
 \NameNum=4
@@ -13,16 +13,23 @@
 \begin{document}
 
 \begin{script}
-	\cut{\name{$1$}}
-	{ああああああああああああああ} 
-	{\begin{audio}
-		\item[] \soundeffect{hoge}
-		\item[] \dialogue[hobe]{foo}
-	\end{audio}}
+	\cut{11}
+	\video{ああああ  \par ああああ }
+	\audio{
+	\soundeffect{ああああ}
+		\dialogue[]{}
+	}
+	\cut{11}
+	\video{ああああ  \par ああああ}
+	\audio{
+	\soundeffect{ああああ}
+		\dialogue[ああああ]{ああああ}
+	}
 
-	
-	\cut{\name{2}} {3} {4}
-\end{script}
+
+
+	\end{script}
+
 
 
 

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -1,6 +1,6 @@
 \documentclass[b5j]{tbook}
 
-\usepackage{framed,color}
+
 \usepackage[utf8]{inputenc}
 \usepackage{longtable}
 \usepackage{graphics}
@@ -9,33 +9,22 @@
 
 %名前の長さ
 \NameNum=4
-\setlength{\fboxrule}{0.5pt}
 
 \begin{document}
-`
-\begin{oframed}
-		\rotatebox{90}{CUT}
-		\rule[-0.5zh]{0.5mm}{3em}
-		\hspace{5em}
-		\raise1em\hbox{画\hspace{1em}面}
-		\hspace{5em}
-		\rule[-0.5zh]{0.5mm}{3em}
-		\hspace{1em}
-		\rule[-0.5zh]{0.5mm}{3em}
-		\hspace{14em}
-		\raise1em\hbox{音\hspace{1em}声}`
-		\hspace{14em}
-\end{oframed}
+
+\begin{script}
+	\begin{cut}
+		\name{123}
+		\begin{video}
+			aaaa
+		\end{video}
+		\begin{audio}
+			\soundeffect{hoge}
+			\dialogue[hobe]{foo}
+			\dialogue{foo}%[]がない場合名前はnameと表示する
+		\end{audio}
+	\end{cut}
+\end{script}
 
 
-%\framebox[3cm][l]{
-	
-%Cut & \rotatebox{90}{画面} & \rotatebox{90}{音声} \\ 
-%Cut & \rotatebox{90}{画面} & \rotatebox{90}{音声} \\ 
-%Cut & \rotatebox{90}{画面} & \rotatebox{90}{音声} \\ 
-
-%\rotatebox{90}{Cut} & 画面 & 音声 \\ 
-
-\soundeffect{hoge}
-%\dialogue[hobe]{foo}
 \end{document}

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -13,20 +13,18 @@
 \begin{document}
 
 \begin{script}
-	\cut{11}
+	\cut{1}
 	\video{ああああ  \par ああああ }
 	\audio{
-	\soundeffect{ああああ}
+		\soundeffect{ああああ}
 		\dialogue[]{}
 	}
-	\cut{11}
+	\cut{1111}
 	\video{ああああ  \par ああああ}
 	\audio{
-	\soundeffect{ああああ}
+		\soundeffect{ああああ}
 		\dialogue[ああああ]{ああああ}
 	}
-
-
 
 	\end{script}
 

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -13,7 +13,19 @@
 \begin{document}
 
 \begin{script}
-	\cut{\name{1}} {sdfasdf} {\soundeffect{hoge} \\ \dialogue[hobe]{foo}}
+	\cut{\name{$1$}}
+	{ああああああああああああああ} 
+	{\begin{audio}
+		\item[] \soundeffect{hoge}
+		\item[] \dialogue[hobe]{foo}
+	\end{audio}}
+
+	
+	\cut{\name{2}} {3} {4}
 \end{script}
+
+
+
+
 
 \end{document}

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -4,7 +4,7 @@
 \usepackage[utf8]{inputenc}
 \usepackage{longtable}
 \usepackage{graphics}
-\usepackage{makecell}
+%\usepackage{makecell}
 \usepackage{script}
 
 %名前の長さ

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -13,18 +13,7 @@
 \begin{document}
 
 \begin{script}
-	\begin{cut}
-		\name{123}
-		\begin{video}
-			aaaa
-		\end{video}
-		\begin{audio}
-			\soundeffect{hoge}
-			\dialogue[hobe]{foo}
-			\dialogue{foo}%[]がない場合名前はnameと表示する
-		\end{audio}
-	\end{cut}
+	\cut{\name{1}} {sdfasdf} {\soundeffect{hoge} \\ \dialogue[hobe]{foo}}
 \end{script}
-
 
 \end{document}

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -8,24 +8,68 @@
 
 %縦の余白設定
 \setlength{\topmargin}{-20mm}
+%横の余白設定
+\setlength{\oddsidemargin}{-10.4mm}  % 左の余白を20mm(=1inch-5.4mm)に
+%\addtolength{\textwidth}{10mm }
 %名前の長さ
 \NameNum=4
 
+\renewcommand{\arraystretch}{10.2}
 \begin{document}
 
 \begin{script}
 	\cut{1}
-	\video{ああああ  \par ああああ }
+	\video{あああああ \par あああああああああああああああああ
+	aaあああ
+\par
+	あさああ
+	}
+	\audio{
+		\soundeffect{あああああああああああああああああ}
+		\dialogue[あああああ]{あああああああああああああああ}
+	}
+	\cut{2}
+	\video{あああああああ }
 	\audio{
 		\soundeffect{ああああ}
-		\dialogue[]{}
+		\dialogue[いいい]{}
 	}
-	\cut{1111}
-	\video{ああああ  \par ああああ}
+
+	\cut{3}
+	\video{ああああ あああ }
 	\audio{
 		\soundeffect{ああああ}
-		\dialogue[ああああ]{ああああ}
+		\dialogue[いい]{}
 	}
+
+	\cut{4}
+	\video{あああああああ }
+	\audio{
+		\soundeffect{ああああ}
+		\dialogue[あああ]{}
+	}
+	\cut{5}
+	\video{あああああああ }
+	\audio{
+		\soundeffect{ああああ}
+		\dialogue[あああ]{}
+	}
+	\cut{10}
+	\video{ああああ \par あa \par aa \par  aa \par あああ }
+	\audio{
+		\soundeffect{ああああ}
+		\dialogue[あああ]{}
+	}
+
+	\cut{11}
+	\video{ああああ あああ }
+	\audio{
+		\soundeffect{ああああ}
+		\dialogue[あああ]{}
+	}
+
+
+
 
 	\end{script}
 

--- a/exsmple.tex
+++ b/exsmple.tex
@@ -1,12 +1,13 @@
 \documentclass[b5j]{tbook}
 
-
 \usepackage[utf8]{inputenc}
 \usepackage{longtable}
-\usepackage{graphics}
+\usepackage{graphicx}
 %\usepackage{makecell}
 \usepackage{script}
 
+%縦の余白設定
+\setlength{\topmargin}{-20mm}
 %名前の長さ
 \NameNum=4
 

--- a/script.sty
+++ b/script.sty
@@ -1,27 +1,34 @@
 
 \newcount\NameNum
+\newcount\ImageSize
+\newcount\AudioSize
 \NameNum=4
+\ImageSize=20
+\AudioSize=30
 
-\newcommand{\soundeffect}[1]{\item[] \hspace{\NameNum em} (SE) #1 }
+\newcommand{\soundeffect}[1]{ \hspace{\NameNum em} (SE) #1 \par} 
+\newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}} }
 
-\newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}}}
+\newcommand{\dialogue}   [2][name]{ \makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
+                                   \BracketsRot{-90}{」} \par}
 
-\newcommand{\dialogue}   [2][name]{\item[] \makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
-                                   \BracketsRot{90}{」}  }
+\newenvironment{script}
+	  {\begin{longtable}{|c |p{\ImageSize em}|p{1em}|p{\AudioSize em}|}
+			  \hline
+			  \BracketsRot{90}{CUT } & 
+				  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}
+				  & & \hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline
+              \endfirsthead
+				  \rotatebox{90}{Cut} & 
+			  	  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}
+				  & &\hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline
+			  \endhead}
+       {\end{longtable}}
 
-	  \newenvironment{script}
-	  	{\begin{longtable}{|l |p{20em}||p{20em}|} \hline
-		\BracketsRot{90}{Cut} & 画面 & 音声 \\ \hline
-                            \endfirsthead
-                            \rotatebox{90}{Cut} & 画面& 音声 \\ \hline
-                            \endhead
-                            \hline}
-                        {\end{longtable}}
+	   \newcommand{\name}[1]{\raisebox{-0.3em}[0em][0em]{\rotatebox{90}{#1}}}
 
-\newcommand{\name}[1]{\rotatebox{90}{#1}}
+	   \newcommand{\cut}[3]{ #1 & \raisebox{1em}[7.5pt][0pt]{} #2  & & #3 \\ \hline}
+\newenvironment{video}{}{  }
+\newenvironment{audio} {}{}
 
-\newcommand{\cut}[3]{#1 & #2 & #3 \\ \hline}
-\newenvironment{video}  {}{}
-\newenvironment{audio}{\begin{itemize}}
-{\end{itemize}}
-
+\newenvironment{cut2}[1]{\name{#1}} {\\}

--- a/script.sty
+++ b/script.sty
@@ -9,8 +9,8 @@
 \newcommand{\soundeffect}[1]{ \hspace{\NameNum em} (SE) #1 \par}
 \newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}}}
 
-\newcommand{\dialogue}   [2][name]{ \makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
-                                   \BracketsRot{-90}{」} \par}
+\newcommand{\dialogue}   [2][name]{\makebox[\NameNum em]{#1} 「 #2 
+                                   」 \par}
 
 \newenvironment{script}
 	  {\begin{longtable}{|c |p{\ImageSize em}|p{1em}|p{\AudioSize em}|}%

--- a/script.sty
+++ b/script.sty
@@ -25,10 +25,16 @@
 			  \endhead}
        {\end{longtable}}
 
-\newcommand{\name}[1]{\raisebox{-0.3em}[0em][0em]{\rotatebox{90}{#1}}}
+%\newcommand{\name}[1]{\raisebox{-0.3em}[0em][0em]{\rotatebox{90}{#1}}}
+	   \newcommand{\name}[2]{\raisebox{-1.5 em}[0em][0em]{\rotatebox{90}{#1}}}
 
-\newcommand{\cut}[1]{\name{#1} &}
-\newcommand{\video}[1]{#1 & & }% \begin{verb}#1\end{verb} & &}
-\newcommand{\audio}[1]{#1 \\ \hline}
+	   \newcommand{\cut}[1]{\\ \name{#1}{\wordcount{#1}} &}
+\newcommand{\video}[1]{\raisebox{1em}[7.5pt][0pt]{} #1 & & }
+\newcommand{\audio}[1]{#1  \\ \hline}
 
-%\newcommand{\cut}[3]{#1 & \raisebox{1em}[7.5pt][0pt]{} #2  & & #3 \\ \hline}
+
+\def\wordcount#1{%
+	\@tempcnta\z@%
+	\@tfor \@tmp:=#1\do{\advance\@tempcnta\@ne}%
+	\the\@tempcnta%
+}

--- a/script.sty
+++ b/script.sty
@@ -6,29 +6,29 @@
 \ImageSize=20
 \AudioSize=30
 
-\newcommand{\soundeffect}[1]{ \hspace{\NameNum em} (SE) #1 \par} 
-\newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}} }
+\newcommand{\soundeffect}[1]{ \hspace{\NameNum em} (SE) #1 \par}
+\newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}}}
 
 \newcommand{\dialogue}   [2][name]{ \makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
                                    \BracketsRot{-90}{」} \par}
 
 \newenvironment{script}
-	  {\begin{longtable}{|c |p{\ImageSize em}|p{1em}|p{\AudioSize em}|}
-			  \hline
-			  \BracketsRot{90}{CUT } & 
-				  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}
-				  & & \hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline
-              \endfirsthead
-				  \rotatebox{90}{Cut} & 
-			  	  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}
-				  & &\hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline
+	  {\begin{longtable}{|c |p{\ImageSize em}|p{1em}|p{\AudioSize em}|}%
+			  \hline%
+			  \BracketsRot{90}{CUT } &%
+				  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}%
+				  & & \hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
+              \endfirsthead%
+				  \rotatebox{90}{Cut} &%
+			  	  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}%
+				  & &\hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
 			  \endhead}
        {\end{longtable}}
 
-	   \newcommand{\name}[1]{\raisebox{-0.3em}[0em][0em]{\rotatebox{90}{#1}}}
+\newcommand{\name}[1]{\raisebox{-0.3em}[0em][0em]{\rotatebox{90}{#1}}}
 
-	   \newcommand{\cut}[3]{ #1 & \raisebox{1em}[7.5pt][0pt]{} #2  & & #3 \\ \hline}
-\newenvironment{video}{}{  }
-\newenvironment{audio} {}{}
+\newcommand{\cut}[1]{\name{#1} &}
+\newcommand{\video}[1]{#1 & & }% \begin{verb}#1\end{verb} & &}
+\newcommand{\audio}[1]{#1 \\ \hline}
 
-\newenvironment{cut2}[1]{\name{#1}} {\\}
+%\newcommand{\cut}[3]{#1 & \raisebox{1em}[7.5pt][0pt]{} #2  & & #3 \\ \hline}

--- a/script.sty
+++ b/script.sty
@@ -1,4 +1,3 @@
-
 \newcount\NameNum
 \newcount\ImageSize
 \newcount\AudioSize
@@ -59,19 +58,23 @@
 			  \hline%
 			  \BracketsRot{90}{CUT } &%
 				  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画　面}%
-				  & & \hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音　声} \\ \hline%
+				  & & \hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音　声} \\ 
+				  \hline%
               \endfirsthead%
-				  \rotatebox{90}{CUT} &%
+			  \hline%
+			  \BracketsRot{90}{CUT } &%
 			  	  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画　面}%
-				  & &\hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音　声} \\ \hline%
+				  & &\hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音　声} \\ 
+				  \hline%
 			  \endhead}
        {\end{longtable}}
 
 \newcommand{\name}[1]{\rotatebox[origin=r]{90}{#1}}
 
-\newcommand{\cut}[1]{\\ \name{#1} &}
-\newcommand{\video}[1]{\raisebox{1em}[7.5pt][0pt]{} #1 & & }
-\newcommand{\audio}[1]{#1  \\ \hline}
+\newcommand{\cut}[1]{\\   \name{#1} &}
+
+\newcommand{\video}[1]{\rule{0cm}{0.4cm} #1 \par  & & }
+\newcommand{\audio}[1]{#1 \par \\ \hline}
 
 \def\wordcount#1{%
 	\@tempcnta\z@%

--- a/script.sty
+++ b/script.sty
@@ -2,24 +2,26 @@
 \newcount\NameNum
 \NameNum=4
 
-\newcommand{\soundeffect}[1]{\hspace{\NameNum em} (SE) #1}
+\newcommand{\soundeffect}[1]{\hspace{\NameNum em} (SE) #1 }
 
-\newcommand{\BracketsRot}[1]{\raise0.5em\hbox{\rotatebox{-90}{#1}}}
+\newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}}}
 
-\newcommand{\dialogue}   [2][name]{\makebox[\NameNum em]{#1} \BracketsRot{「} #2 \BracketsRot{」}}
+\newcommand{\dialogue}   [2][name]{\makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
+                                   \BracketsRot{90}{」}  }
 
-\newenvironment{script} {\begin{longtable}{|l|l|l|} \hline
-							Cut & 画面& 音声 \\ \hline
-							\endfirsthead
-							Cut & 画面& 音声 \\ \hline
-							\endhead
-							\hline}
-						{\end{longtable}}
-\newcommand{\name}[1]{#1}
+	  \newenvironment{script}
+	  	{\begin{longtable}{|l |p{20em}||p{20em}|} \hline
+		\BracketsRot{90}{Cut} & 画面 & 音声 \\ \hline
+                            \endfirsthead
+                            \rotatebox{90}{Cut} & 画面& 音声 \\ \hline
+                            \endhead
+                            \hline}
+                        {\end{longtable}}
+
+\newcommand{\name}[1]{\rotatebox{90}{#1}}
 
 \newcommand{\cut}[3]{#1 & #2 & #3 \\ \hline}
-\newenvironment{video} {}{}
-\newenvironment{audio} {}{}
-
-
+\newenvironment{video}  {}{}
+\newenvironment{audio}{\begin{itemize}}
+{\end{itemize}}
 

--- a/script.sty
+++ b/script.sty
@@ -4,31 +4,33 @@
 \newcount\AudioSize
 \newcount\ImageHurfSize
 \newcount\AudioHurfSize
+\newcount\spaceSize
 \NameNum=4
 \ImageSize=20
-\AudioSize=30
+\spaceSize=0
+\AudioSize=40
 
 \newcount\hurfTmp
 
-%画面の中央を計算
+%音声の中央を計算
 \hurfTmp=0
 \AudioHurfSize=\AudioSize
 \divide\ImageHurfSize by 2 
-\advance\hurfTmp by \ImageHurfSize 
+\advance\hurfTmp by \AudioHurfSize 
 \multiply\hurfTmp by 2 
-\ImageHurfSize=\AudioSize \relax
-\advance\ImageHurfSize by -\hurfTmp
+\AudioHurfSize=\AudioSize \relax
+\advance\AudioHurfSize by -\hurfTmp
 \if\ImageHurfSize > 0 
-	\AmageHurfSize=-1 
+	\AmageHurfSize=-1
 \else 
-	\AudioHurfSize=0 
+	\AudioHurfSize=0
 \fi 
+\advance\AudioHurfSize by -3
 \hurfTmp=\AudioSize
 \divide\hurfTmp by 2 
 \advance\AudioHurfSize by \hurfTmp
 
-
-%音声の中央を計算
+%画面の中央を計算
 \hurfTmp=0
 \ImageHurfSize=\ImageSize
 \divide\ImageHurfSize by 2 
@@ -37,10 +39,11 @@
 \ImageHurfSize=\ImageSize \relax
 \advance\ImageHurfSize by -\hurfTmp
 \if\ImageHurfSize > 0 
-	\ImageHurfSize=-1 
+	\ImageHurfSize=-1
 \else 
-  \ImageHurfSize=0 
+  \ImageHurfSize=0
 \fi 
+\advance\ImageHurfSize by -3
 \hurfTmp=\ImageSize
 \divide\hurfTmp by 2 
 \advance\ImageHurfSize by \hurfTmp
@@ -52,21 +55,21 @@
                                    」 \par}
 
 \newenvironment{script}
-	  {\begin{longtable}{|c |p{\ImageSize em}|p{1em}|p{\AudioSize em}|}%
+	  {\begin{longtable}{|c |p{\ImageSize em}|p{\spaceSize em}|p{\AudioSize em}|}%
 			  \hline%
 			  \BracketsRot{90}{CUT } &%
-				  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画  面}%
-				  & & \hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
+				  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画　面}%
+				  & & \hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音　声} \\ \hline%
               \endfirsthead%
-				  \rotatebox{90}{Cut} &%
-			  	  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画  面}%
-				  & &\hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
+				  \rotatebox{90}{CUT} &%
+			  	  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画　面}%
+				  & &\hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音　声} \\ \hline%
 			  \endhead}
        {\end{longtable}}
 
-\newcommand{\name}[2]{\raisebox{-1.5 em}[0em][0em]{\rotatebox{90}{#1}}}
+\newcommand{\name}[1]{\rotatebox[origin=r]{90}{#1}}
 
-\newcommand{\cut}[1]{\\ \name{#1}{\wordcount{#1}} &}
+\newcommand{\cut}[1]{\\ \name{#1} &}
 \newcommand{\video}[1]{\raisebox{1em}[7.5pt][0pt]{} #1 & & }
 \newcommand{\audio}[1]{#1  \\ \hline}
 

--- a/script.sty
+++ b/script.sty
@@ -2,9 +2,48 @@
 \newcount\NameNum
 \newcount\ImageSize
 \newcount\AudioSize
+\newcount\ImageHurfSize
+\newcount\AudioHurfSize
 \NameNum=4
 \ImageSize=20
 \AudioSize=30
+
+\newcount\hurfTmp
+
+%画面の中央を計算
+\hurfTmp=0
+\AudioHurfSize=\AudioSize
+\divide\ImageHurfSize by 2 
+\advance\hurfTmp by \ImageHurfSize 
+\multiply\hurfTmp by 2 
+\ImageHurfSize=\AudioSize \relax
+\advance\ImageHurfSize by -\hurfTmp
+\if\ImageHurfSize > 0 
+	\AmageHurfSize=-1 
+\else 
+	\AudioHurfSize=0 
+\fi 
+\hurfTmp=\AudioSize
+\divide\hurfTmp by 2 
+\advance\AudioHurfSize by \hurfTmp
+
+
+%音声の中央を計算
+\hurfTmp=0
+\ImageHurfSize=\ImageSize
+\divide\ImageHurfSize by 2 
+\advance\hurfTmp by \ImageHurfSize 
+\multiply\hurfTmp by 2 
+\ImageHurfSize=\ImageSize \relax
+\advance\ImageHurfSize by -\hurfTmp
+\if\ImageHurfSize > 0 
+	\ImageHurfSize=-1 
+\else 
+  \ImageHurfSize=0 
+\fi 
+\hurfTmp=\ImageSize
+\divide\hurfTmp by 2 
+\advance\ImageHurfSize by \hurfTmp
 
 \newcommand{\soundeffect}[1]{ \hspace{\NameNum em} (SE) #1 \par}
 \newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}}}
@@ -16,22 +55,20 @@
 	  {\begin{longtable}{|c |p{\ImageSize em}|p{1em}|p{\AudioSize em}|}%
 			  \hline%
 			  \BracketsRot{90}{CUT } &%
-				  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}%
-				  & & \hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
+				  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画  面}%
+				  & & \hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
               \endfirsthead%
 				  \rotatebox{90}{Cut} &%
-			  	  \hspace{6.5em} \raisebox{1.5em}[0em][0em]{画  面}%
-				  & &\hspace{13.5em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
+			  	  \hspace{\ImageHurfSize em} \raisebox{1.5em}[0em][0em]{画  面}%
+				  & &\hspace{\AudioHurfSize em} \raisebox{1.5em}[0em][0em]{音 声} \\ \hline%
 			  \endhead}
        {\end{longtable}}
 
-%\newcommand{\name}[1]{\raisebox{-0.3em}[0em][0em]{\rotatebox{90}{#1}}}
-	   \newcommand{\name}[2]{\raisebox{-1.5 em}[0em][0em]{\rotatebox{90}{#1}}}
+\newcommand{\name}[2]{\raisebox{-1.5 em}[0em][0em]{\rotatebox{90}{#1}}}
 
-	   \newcommand{\cut}[1]{\\ \name{#1}{\wordcount{#1}} &}
+\newcommand{\cut}[1]{\\ \name{#1}{\wordcount{#1}} &}
 \newcommand{\video}[1]{\raisebox{1em}[7.5pt][0pt]{} #1 & & }
 \newcommand{\audio}[1]{#1  \\ \hline}
-
 
 \def\wordcount#1{%
 	\@tempcnta\z@%

--- a/script.sty
+++ b/script.sty
@@ -2,11 +2,11 @@
 \newcount\NameNum
 \NameNum=4
 
-\newcommand{\soundeffect}[1]{\hspace{\NameNum em} (SE) #1 }
+\newcommand{\soundeffect}[1]{\item[] \hspace{\NameNum em} (SE) #1 }
 
 \newcommand{\BracketsRot}[2]{\raise0.5em\hbox{\rotatebox{#1}{#2}}}
 
-\newcommand{\dialogue}   [2][name]{\makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
+\newcommand{\dialogue}   [2][name]{\item[] \makebox[\NameNum em]{#1} \BracketsRot{-90}{「} #2 
                                    \BracketsRot{90}{」}  }
 
 	  \newenvironment{script}

--- a/script.sty
+++ b/script.sty
@@ -8,10 +8,18 @@
 
 \newcommand{\dialogue}   [2][name]{\makebox[\NameNum em]{#1} \BracketsRot{「} #2 \BracketsRot{」}}
 
-\newcommand{\name}[1]{}
-\newenvironment{script}{}{}
-\newenvironment{cut}   {}{}
+\newenvironment{script} {\begin{longtable}{|l|l|l|} \hline
+							Cut & 画面& 音声 \\ \hline
+							\endfirsthead
+							Cut & 画面& 音声 \\ \hline
+							\endhead
+							\hline}
+						{\end{longtable}}
+\newcommand{\name}[1]{#1}
+
+\newcommand{\cut}[3]{#1 & #2 & #3 \\ \hline}
 \newenvironment{video} {}{}
 \newenvironment{audio} {}{}
+
 
 

--- a/script.sty
+++ b/script.sty
@@ -6,4 +6,12 @@
 
 \newcommand{\BracketsRot}[1]{\raise0.5em\hbox{\rotatebox{-90}{#1}}}
 
-\newcommand{\dialogue}[2][name]{\makebox[\NameNum em]{#1} \BracketsRot{「} #2 \BracketsRot{」}}
+\newcommand{\dialogue}   [2][name]{\makebox[\NameNum em]{#1} \BracketsRot{「} #2 \BracketsRot{」}}
+
+\newcommand{\name}[1]{}
+\newenvironment{script}{}{}
+\newenvironment{cut}   {}{}
+\newenvironment{video} {}{}
+\newenvironment{audio} {}{}
+
+


### PR DESCRIPTION
マクロの制作の都合上 \begin{cut} \begin{video} \begin{audio} ... \end{cut} のような形式ではなく \cut {name}{video}{audio}と言うような形式にしました。
LaTeXのバグの都合上 TeXlive 2015 でうまく動作しません。
最新のバージョンではうまく動作します。